### PR TITLE
Fix space on the HTTP response

### DIFF
--- a/waybackproxy.py
+++ b/waybackproxy.py
@@ -412,7 +412,7 @@ class Handler(socketserver.BaseRequestHandler):
 		if isinstance(conn, urllib.error.HTTPError):
 			response += '{0} {1}'.format(conn.code, conn.reason.replace('\n', ' '))
 		else:
-			response += '200 OK'
+			response += ' 200 OK'
 
 		# Add content type, and the ETag for caching.
 		response += '\r\nContent-Type: ' + content_type + '\r\nETag: "' + request_url.replace('"', '') + '"\r\n'


### PR DESCRIPTION
It is missing one space before the 200 OK response.

Without it, I got `HTTP/1.1200 OK`. It should be `HTTP/1.1 200 OK`