### PR TITLE
Add pass-through whitelisting functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ WaybackProxy is a retro-friendly HTTP proxy which retrieves pages from the [Inte
 		* The easiest way to set up a transparent WaybackProxy is to run it on port 80 ([this cannot be done on Linux without security implications](https://unix.stackexchange.com/questions/87348/capabilities-for-a-script-on-linux)\), set up a fake DNS server - such as `dnsmasq -A "/#/ip"` where `ip` is the IP of the system running WaybackProxy - to redirect all requests to the proxy, and point client machines at that DNS server.
 4. Try it out! You can edit most settings that are in `config.py` by browsing to http://web.archive.org while on the proxy, although you must edit `config.py` to make them permanent.
 5. Press Ctrl+C to stop the proxy
+6. Exclude domains from being proxied by adding them to `whitelist.txt`
 
 ## Known issues and limitations
 

--- a/waybackproxy.py
+++ b/waybackproxy.py
@@ -28,6 +28,15 @@ class Handler(socketserver.BaseRequestHandler):
 		# Store a local pointer to SharedState.
 		self.shared_state = shared_state
 
+		# Read domain whitelist file.
+		try:
+			whitelist_file = open("whitelist.txt","r")
+			whitelist_data = whitelist_file.read()
+			self.whitelist = whitelist_data.split("\n")
+			whitelist_file.close()
+		except:
+			self.whitelist = list()
+
 	def handle(self):
 		"""Handle a request."""
 
@@ -113,6 +122,8 @@ class Handler(socketserver.BaseRequestHandler):
 				pac += '''}\r\n'''
 				self.request.sendall(pac.encode('ascii', 'ignore'))
 				return
+			elif hostname in self.whitelist:
+				_print('[>]', archived_url,'(proxy bypassed by whitelist.txt)')
 			elif hostname == 'web.archive.org':
 				if path[:5] != '/web/':
 					# Launch settings if enabled.

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -2,3 +2,7 @@ frogfind.com
 www.frogfind.com
 www.floodgap.com
 gopher.floodgap.com
+68k.news
+www.68k.news
+yarchive.net
+www.yarchive.net

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -1,0 +1,4 @@
+frogfind.com
+www.frogfind.com
+www.floodgap.com
+gopher.floodgap.com


### PR DESCRIPTION
There are many sites out there that are still useful or even targeted to legacy systems and browsers nowadays, and to better integrate them with the proxy in my usage I have added a simple whitelisting system that bypasses proxying for any domains listed in a file called `whitelist.txt` in the same directory as the main script. With this, you can now use the proxy while also still being able to access new or still-extant sites that run well on your system, like FrogFind or Floodgap that are both provided as examples in the default whitelist.

All changes are implemented in the `Handler` class:
- When a `Handler` is instantiated, it will now attempt to read from a file named `whitelist.txt` in the script directory
- The contents of `whitelist.txt` will be read and split by `\n` into a list property `self.whitelist`
- If `whitelist.txt` does not exist or cannot be opened, `self.whitelist` will be initialized to an empty list instead
- If the determined `hostname` variable matches any member of `self.whitelist`, the proxy will request the URL as-is.

One caveat to this current implementation is that it does not pass through to subdomains, so separate lines on the file will be needed for `domain.com` and `www.domain.com` as examples. Reading in the file with every request does not appear to have any meaningful performance impact in my testing and allows for on-demand updates without restarting the proxy.

Thank you for your time, and please let me know if you have any questions or ideas to improve these changes. 