### PR TITLE
Different config files, multi-run and autostart

### DIFF
--- a/config1997.json
+++ b/config1997.json
@@ -1,6 +1,6 @@
 {
-    "LISTEN_PORT": 8887,
-    "DATE": "20010818",
+    "LISTEN_PORT": 1997,
+    "DATE": "19970801",
     "DATE_TOLERANCE": 365,
     "GEOCITIES_FIX": true,
     "QUICK_IMAGES": true,

--- a/config2000.json
+++ b/config2000.json
@@ -1,6 +1,6 @@
 {
-    "LISTEN_PORT": 8887,
-    "DATE": "20010818",
+    "LISTEN_PORT": 2000,
+    "DATE": "20000801",
     "DATE_TOLERANCE": 365,
     "GEOCITIES_FIX": true,
     "QUICK_IMAGES": true,

--- a/config2004.json
+++ b/config2004.json
@@ -1,6 +1,6 @@
 {
-    "LISTEN_PORT": 8887,
-    "DATE": "20010818",
+    "LISTEN_PORT": 2004,
+    "DATE": "20040801",
     "DATE_TOLERANCE": 365,
     "GEOCITIES_FIX": true,
     "QUICK_IMAGES": true,

--- a/config_handler.py
+++ b/config_handler.py
@@ -1,53 +1,50 @@
 import json
+import os
 
-# Listen port for the HTTP proxy.
-global LISTEN_PORT
+# # Listen port for the HTTP proxy.
+# global LISTEN_PORT
 
-# Date to get pages from Wayback. YYYYMMDD, YYYYMM and YYYY formats are
-# accepted, the more specific the better.
-global DATE 
+# # Date to get pages from Wayback. YYYYMMDD, YYYYMM and YYYY formats are
+# # accepted, the more specific the better.
+# global DATE 
 
-# Allow the client to load pages and assets up to X days after DATE.
-# Set to None to disable this restriction.
-global DATE_TOLERANCE
+# # Allow the client to load pages and assets up to X days after DATE.
+# # Set to None to disable this restriction.
+# global DATE_TOLERANCE
 
-# Send Geocities requests to oocities.org if set to True.
-global GEOCITIES_FIX
+# # Send Geocities requests to oocities.org if set to True.
+# global GEOCITIES_FIX
 
-# Use the original Wayback Machine URL as a shortcut when loading images.
-# May result in faster page loads, but all images will point to
-# http://web.archive.org/... as a side effect. Set this value to 2 to enable an
-# experimental mode using authentication on top of the original URLs instead
-# (which is not supported by Internet Explorer and some other browsers).
-global QUICK_IMAGES
+# # Use the original Wayback Machine URL as a shortcut when loading images.
+# # May result in faster page loads, but all images will point to
+# # http://web.archive.org/... as a side effect. Set this value to 2 to enable an
+# # experimental mode using authentication on top of the original URLs instead
+# # (which is not supported by Internet Explorer and some other browsers).
+# global QUICK_IMAGES
 
-# Use the Wayback Machine Availability API to find the closest available
-# snapshot to the desired date, instead of directly requesting that date. Helps
-# in situations where an image returns a server error on the desired date, but
-# is available at an earlier date. As a side effect, pages will take longer to
-# load due to the added API call. If enabled, this option will disable the
-# QUICK_IMAGES bypass mechanism built into the PAC file.
-global WAYBACK_API
+# # Use the Wayback Machine Availability API to find the closest available
+# # snapshot to the desired date, instead of directly requesting that date. Helps
+# # in situations where an image returns a server error on the desired date, but
+# # is available at an earlier date. As a side effect, pages will take longer to
+# # load due to the added API call. If enabled, this option will disable the
+# # QUICK_IMAGES bypass mechanism built into the PAC file.
+# global WAYBACK_API
 
-# Allow the Content-Type header to contain an encoding. Some old browsers
-# (Mosaic?) don't understand that and fail to load anything - set this to
-# False if you're using one of them.
-global CONTENT_TYPE_ENCODING
+# # Allow the Content-Type header to contain an encoding. Some old browsers
+# # (Mosaic?) don't understand that and fail to load anything - set this to
+# # False if you're using one of them.
+# global CONTENT_TYPE_ENCODING
 
-# Disables logging if set to True.
-global SILENT
+# # Disables logging if set to True.
+# global SILENT
 
-# Enables the settings page on http://web.archive.org if set to True.
-global SETTINGS_PAGE
+# # Enables the settings page on http://web.archive.org if set to True.
+# global SETTINGS_PAGE
 
-with open('config.json', 'r', encoding='utf8', errors='ignore') as f:
-	data = json.loads(f.read())
-	LISTEN_PORT = data['LISTEN_PORT']
-	DATE = data['DATE']
-	DATE_TOLERANCE = data['DATE_TOLERANCE']
-	GEOCITIES_FIX = data['GEOCITIES_FIX']
-	QUICK_IMAGES = data['QUICK_IMAGES']
-	WAYBACK_API = data['WAYBACK_API']
-	CONTENT_TYPE_ENCODING = data['CONTENT_TYPE_ENCODING']
-	SILENT = data['SILENT']
-	SETTINGS_PAGE = data['SETTINGS_PAGE']
+def load_config(file_name='config.json'):
+    if not os.path.isabs(file_name):
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+        file_name = os.path.join(dir_path, file_name)
+    
+    with open(file_name, 'r', encoding='utf8', errors='ignore') as f:
+        return json.loads(f.read())

--- a/run_waybackproxy.sh
+++ b/run_waybackproxy.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+python3 "$SCRIPT_DIR/waybackproxy.py" -c "$SCRIPT_DIR/config2000.json" &
+
+python3 "$SCRIPT_DIR/waybackproxy.py" -c "$SCRIPT_DIR/config1997.json" &
+
+python3 "$SCRIPT_DIR/waybackproxy.py" -c "$SCRIPT_DIR/config2004.json" &
+
+wait

--- a/setup_waybackproxy_service.sh
+++ b/setup_waybackproxy_service.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPT_PATH="$SCRIPT_DIR/run_waybackproxy.sh"
+
+SERVICE_FILE="waybackproxy.service"
+
+cat << EOF | sudo tee /etc/systemd/system/$SERVICE_FILE > /dev/null
+[Unit]
+Description=Wayback Proxy Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash $SCRIPT_PATH
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+
+sudo systemctl enable $SERVICE_FILE
+
+echo "Wayback Proxy Service is installed and enabled. "


### PR DESCRIPTION

Hello, for my purposes, to have internet from a different era on each of my computers, I modified the code and thought you might want to import some of it.

1. The main change is the abandonment of global variables and the use of a variable with a dictionary
2. Possibility to run the script with the -c config.json attribute. This allows you to have several configurations
3. config_handler now returns an object with the configuration that it loads from the given attribute or the default config.json file
4. I added the run_waybackproxy.sh file which runs three instances with sample configuration
5. The setup_waybackproxy_service.sh script creates a waybackproxy.service file that can be started by systemd at system startup