### PR TITLE
#43 Support binding to a specific interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ When deploying via Docker, the config.json can be customized by specifying envir
 
 | Parameter        | Default | Description                            |
 |------------------|---------|----------------------------------------|
+| `HOST` | `''` | Host address to bind to for the HTTP proxy (default of `''` means "all interfaces") |
 | `LISTEN_PORT` | 8888 | Listen port for the HTTP proxy |
 | `DATE` | 20011025 | Date to get pages from Wayback. YYYYMMDD, YYYYMM and YYYY formats are accepted, the more specific the better.|
 | `DATE_TOLERANCE` | 365 | Allow the client to load pages and assets up to X days after DATE. Set to None to disable this restriction.|

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "HOST": "",
     "LISTEN_PORT": 8888,
     "DATE": "20011025",
     "DATE_TOLERANCE": 365,

--- a/config_handler.py
+++ b/config_handler.py
@@ -1,5 +1,9 @@
 import json
 
+# Host address to bind to for the HTTP proxy (default of "" means "all
+# interfaces").
+global HOST
+
 # Listen port for the HTTP proxy.
 global LISTEN_PORT
 
@@ -42,6 +46,7 @@ global SETTINGS_PAGE
 
 with open('config.json', 'r', encoding='utf8', errors='ignore') as f:
 	data = json.loads(f.read())
+	HOST = data.get('HOST', '')
 	LISTEN_PORT = data['LISTEN_PORT']
 	DATE = data['DATE']
 	DATE_TOLERANCE = data['DATE_TOLERANCE']

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+if [ "${HOST}" ]; then
+    sed -i -e "s/\"HOST\":[^,]*/\"HOST\": ${HOST}/g" /app/config.json
+fi
 if [ "${LISTEN_PORT}" ]; then
     sed -i -e "s/\"LISTEN_PORT\":[^,]*/\"LISTEN_PORT\": ${LISTEN_PORT}/g" /app/config.json
 fi

--- a/waybackproxy.py
+++ b/waybackproxy.py
@@ -730,8 +730,8 @@ def _print(*args, **kwargs):
 
 def main():
 	"""Starts the server."""
-	server = ThreadingTCPServer(('', LISTEN_PORT), Handler)
-	_print('[-] Now listening on port', LISTEN_PORT)
+	server = ThreadingTCPServer((HOST, LISTEN_PORT), Handler)
+	_print('[-] Now listening on', '' if HOST == '' else (' on ' + HOST), ' port ', LISTEN_PORT, sep='')
 	_print('[-] Date set to', DATE)
 	try:
 		server.serve_forever()

--- a/waybackproxy.py
+++ b/waybackproxy.py
@@ -530,11 +530,13 @@ class Handler(socketserver.BaseRequestHandler):
 
 	def send_passthrough(self, conn, http_version, content_type, request_url):
 		"""Pass data through to the client unmodified (save for our headers)."""
-		self.send_response_headers(conn, http_version, content_type, request_url, content_length=True)
-		for data in conn.stream(1024):
-			self.request.sendall(data)
-		conn.release_conn()
-		self.request.close()
+		try:
+			self.send_response_headers(conn, http_version, content_type, request_url, content_length=True)
+			for data in conn.stream(1024):
+				self.request.sendall(data)
+		finally:
+			self.drain_conn(conn)
+			self.request.close()
 
 	def send_response_headers(self, conn, http_version, content_type, request_url, content_length=False):
 		"""Generate and send the response headers."""


### PR DESCRIPTION
I'm running WaybackProxy on a VPN (for vintage computers), and I only want clients on the VPN to connect to the proxy (instead of anything else on the broader network), so I added an option to only bind to the given host interface/IP address.

Obviously, this could be enforced at the firewall level as well, but I think it should be an option in the proxy itself.