### PR TITLE
#45 Always return passthrough connections to pool

### DIFF
--- a/waybackproxy.py
+++ b/waybackproxy.py
@@ -530,11 +530,13 @@ class Handler(socketserver.BaseRequestHandler):
 
 	def send_passthrough(self, conn, http_version, content_type, request_url):
 		"""Pass data through to the client unmodified (save for our headers)."""
-		self.send_response_headers(conn, http_version, content_type, request_url, content_length=True)
-		for data in conn.stream(1024):
-			self.request.sendall(data)
-		conn.release_conn()
-		self.request.close()
+		try:
+			self.send_response_headers(conn, http_version, content_type, request_url, content_length=True)
+			for data in conn.stream(1024):
+				self.request.sendall(data)
+		finally:
+			self.drain_conn(conn)
+			self.request.close()
 
 	def send_response_headers(self, conn, http_version, content_type, request_url, content_length=False):
 		"""Generate and send the response headers."""


### PR DESCRIPTION
I was seeing the proxy get "stuck" after running for a bit, apparently due to the connection pool getting exhausted. Although I couldn't reproduce the issue 100% of the time, the issue seemed to revolve around "passthrough" responses hitting "broken pipe" (client web browser closed the connection) errors.

This fix attempts to ensure the connection is *always* read and closed, even in case of error. After applying this fix, I no longer see the pool exhaustion issue.